### PR TITLE
회원가입 기능 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/
+application-mysql.yml
 
 ### STS ###
 .apt_generated

--- a/build.gradle
+++ b/build.gradle
@@ -25,8 +25,11 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
+
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.springframework.security:spring-security-crypto'
 
 	runtimeOnly 'com.mysql:mysql-connector-j'
 

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
+	runtimeOnly 'com.mysql:mysql-connector-j'
+
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 

--- a/src/main/java/com/soundbar91/retrospect_project/Service/UserService.java
+++ b/src/main/java/com/soundbar91/retrospect_project/Service/UserService.java
@@ -19,9 +19,8 @@ public class UserService {
     @Transactional
     public ResponseUser createUser(RequestCreateUser requestCreateUser) {
         String password = passwordEncoder.encode(requestCreateUser.password());
-        userRepository.save(requestCreateUser.toEntity(password));
-        userRepository.flush();
+        User user = userRepository.save(requestCreateUser.toEntity(password));
 
-        return ResponseUser.from(userRepository.getByEmail(requestCreateUser.email()));
+        return ResponseUser.from(user);
     }
 }

--- a/src/main/java/com/soundbar91/retrospect_project/Service/UserService.java
+++ b/src/main/java/com/soundbar91/retrospect_project/Service/UserService.java
@@ -1,0 +1,27 @@
+package com.soundbar91.retrospect_project.Service;
+
+import com.soundbar91.retrospect_project.controller.dto.request.RequestCreateUser;
+import com.soundbar91.retrospect_project.controller.dto.response.ResponseUser;
+import com.soundbar91.retrospect_project.entity.User;
+import com.soundbar91.retrospect_project.repository.UserRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Transactional
+    public ResponseUser createUser(RequestCreateUser requestCreateUser) {
+        String password = passwordEncoder.encode(requestCreateUser.password());
+        userRepository.save(requestCreateUser.toEntity(password));
+        userRepository.flush();
+
+        return ResponseUser.from(userRepository.getByEmail(requestCreateUser.email()));
+    }
+}

--- a/src/main/java/com/soundbar91/retrospect_project/config/SecurityConfig.java
+++ b/src/main/java/com/soundbar91/retrospect_project/config/SecurityConfig.java
@@ -1,0 +1,16 @@
+package com.soundbar91.retrospect_project.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+}

--- a/src/main/java/com/soundbar91/retrospect_project/controller/UserController.java
+++ b/src/main/java/com/soundbar91/retrospect_project/controller/UserController.java
@@ -1,4 +1,27 @@
 package com.soundbar91.retrospect_project.controller;
 
+import com.soundbar91.retrospect_project.Service.UserService;
+import com.soundbar91.retrospect_project.controller.dto.request.RequestCreateUser;
+import com.soundbar91.retrospect_project.controller.dto.response.ResponseUser;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/member")
+@RequiredArgsConstructor
 public class UserController {
+
+    private final UserService userService;
+
+    @PostMapping("/create")
+    public ResponseEntity<ResponseUser> createUser(
+            @RequestBody RequestCreateUser requestCreateUser
+    ) {
+        ResponseUser user = userService.createUser(requestCreateUser);
+        return ResponseEntity.ok(user);
+    }
 }

--- a/src/main/java/com/soundbar91/retrospect_project/controller/UserController.java
+++ b/src/main/java/com/soundbar91/retrospect_project/controller/UserController.java
@@ -1,0 +1,4 @@
+package com.soundbar91.retrospect_project.controller;
+
+public class UserController {
+}

--- a/src/main/java/com/soundbar91/retrospect_project/controller/dto/request/RequestCreateUser.java
+++ b/src/main/java/com/soundbar91/retrospect_project/controller/dto/request/RequestCreateUser.java
@@ -1,0 +1,15 @@
+package com.soundbar91.retrospect_project.controller.dto.request;
+
+import com.soundbar91.retrospect_project.entity.User;
+
+public record RequestCreateUser(
+        String email,
+        String password
+) {
+    public User toEntity() {
+        return User.builder()
+                .email(this.email)
+                .password(this.password)
+                .build();
+    }
+}

--- a/src/main/java/com/soundbar91/retrospect_project/controller/dto/request/RequestCreateUser.java
+++ b/src/main/java/com/soundbar91/retrospect_project/controller/dto/request/RequestCreateUser.java
@@ -6,10 +6,10 @@ public record RequestCreateUser(
         String email,
         String password
 ) {
-    public User toEntity() {
+    public User toEntity(String password) {
         return User.builder()
                 .email(this.email)
-                .password(this.password)
+                .password(password)
                 .build();
     }
 }

--- a/src/main/java/com/soundbar91/retrospect_project/controller/dto/response/ResponseUser.java
+++ b/src/main/java/com/soundbar91/retrospect_project/controller/dto/response/ResponseUser.java
@@ -1,0 +1,21 @@
+package com.soundbar91.retrospect_project.controller.dto.response;
+
+import com.soundbar91.retrospect_project.entity.User;
+
+public record ResponseUser(
+        Long id,
+        String email,
+        int level,
+        double exp,
+        String rol
+) {
+    public ResponseUser from(User user) {
+        return new ResponseUser(
+                user.getId(),
+                user.getEmail(),
+                user.getLevel(),
+                user.getExp(),
+                user.getRole()
+        );
+    }
+}

--- a/src/main/java/com/soundbar91/retrospect_project/controller/dto/response/ResponseUser.java
+++ b/src/main/java/com/soundbar91/retrospect_project/controller/dto/response/ResponseUser.java
@@ -9,7 +9,7 @@ public record ResponseUser(
         double exp,
         String rol
 ) {
-    public ResponseUser from(User user) {
+    public static ResponseUser from(User user) {
         return new ResponseUser(
                 user.getId(),
                 user.getEmail(),

--- a/src/main/java/com/soundbar91/retrospect_project/entity/User.java
+++ b/src/main/java/com/soundbar91/retrospect_project/entity/User.java
@@ -1,13 +1,17 @@
 package com.soundbar91.retrospect_project.entity;
 
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
 
 import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
 
 @Entity
 @Getter
+@NoArgsConstructor(access = PROTECTED)
 @Table(name = "user")
 public class User {
 
@@ -32,4 +36,13 @@ public class User {
     @Column(length = 5)
     @ColumnDefault("'user'")
     private String role;
+
+    @Builder
+    public User(String email, String password, int level, double exp, String role) {
+        this.email = email;
+        this.password = password;
+        this.level = level;
+        this.exp = exp;
+        this.role = role;
+    }
 }

--- a/src/main/java/com/soundbar91/retrospect_project/entity/User.java
+++ b/src/main/java/com/soundbar91/retrospect_project/entity/User.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.DynamicInsert;
 
 import static jakarta.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
@@ -12,6 +13,7 @@ import static lombok.AccessLevel.PROTECTED;
 @Entity
 @Getter
 @NoArgsConstructor(access = PROTECTED)
+@DynamicInsert
 @Table(name = "user")
 public class User {
 
@@ -22,18 +24,18 @@ public class User {
     @Column(nullable = false, unique = true, length = 100)
     private String email;
 
-    @Column(nullable = false, length = 20)
+    @Column(nullable = false)
     private String password;
 
-    @Column
+    @Column(insertable = false)
     @ColumnDefault("1")
     private int level;
 
-    @Column
+    @Column(insertable = false)
     @ColumnDefault("0.0")
     private double exp;
 
-    @Column(length = 5)
+    @Column(length = 5, insertable = false)
     @ColumnDefault("'user'")
     private String role;
 

--- a/src/main/java/com/soundbar91/retrospect_project/entity/User.java
+++ b/src/main/java/com/soundbar91/retrospect_project/entity/User.java
@@ -1,0 +1,35 @@
+package com.soundbar91.retrospect_project.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import org.hibernate.annotations.ColumnDefault;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+
+@Entity
+@Getter
+@Table(name = "user")
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true, length = 100)
+    private String email;
+
+    @Column(nullable = false, length = 20)
+    private String password;
+
+    @Column
+    @ColumnDefault("1")
+    private int level;
+
+    @Column
+    @ColumnDefault("0.0")
+    private double exp;
+
+    @Column(length = 5)
+    @ColumnDefault("'user'")
+    private String role;
+}

--- a/src/main/java/com/soundbar91/retrospect_project/repository/UserRepository.java
+++ b/src/main/java/com/soundbar91/retrospect_project/repository/UserRepository.java
@@ -6,4 +6,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
+    User getByEmail(String email);
 }

--- a/src/main/java/com/soundbar91/retrospect_project/repository/UserRepository.java
+++ b/src/main/java/com/soundbar91/retrospect_project/repository/UserRepository.java
@@ -1,0 +1,9 @@
+package com.soundbar91.retrospect_project.repository;
+
+import com.soundbar91.retrospect_project.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+}

--- a/src/main/java/com/soundbar91/retrospect_project/repository/UserRepository.java
+++ b/src/main/java/com/soundbar91/retrospect_project/repository/UserRepository.java
@@ -6,5 +6,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
-    User getByEmail(String email);
+
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=retrospect-project

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,11 @@
+spring:
+  config:
+    import: application-mysql.yml
+  jpa:
+    database: mysql
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        show_sql: true
+        format_sql: true


### PR DESCRIPTION
이메일과 비밀번호를 입력받아 회원가입을 수행

수정해야할 점
1. 회원 조회 기능이 구현되면 MemberController의 memberCreate 메소드 내부에 해당 기능 추가하기 -> 현재 역할이 null로 출력

생각해봐야할 내용
1. 유저의 아이디를 입력받아 이를 식별자로 하는건 어떨까? -> 백준의 경우 마이페이지에 들어가니 경로가 /member/{유저아이디} 이런 형태였음. 사용자 검색을 자동으로 생성하는 id가 아닌 입력받은 아이디 혹은 이메일로 변경해야할 필요가 있어 보임