### PR TITLE
문제 검색 기능 추가

### DIFF
--- a/src/main/java/com/soundbar91/retrospect_project/Service/ProblemService.java
+++ b/src/main/java/com/soundbar91/retrospect_project/Service/ProblemService.java
@@ -7,9 +7,14 @@ import com.soundbar91.retrospect_project.entity.Problem;
 import com.soundbar91.retrospect_project.entity.User;
 import com.soundbar91.retrospect_project.repository.ProblemRepository;
 import com.soundbar91.retrospect_project.repository.UserRepository;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.TypedQuery;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -17,6 +22,7 @@ public class ProblemService {
 
     private final ProblemRepository problemRepository;
     private final UserRepository userRepository;
+    private final EntityManager entityManager;
 
     @Transactional
     public ResponseProblem createProblem(RequestCreateProblem requestCreateProblem) {
@@ -29,6 +35,21 @@ public class ProblemService {
         return ResponseProblem.from(problem);
     }
 
+    public List<ResponseProblem> findProblemByParams(
+            Long id, String title, Integer level, String algorithms
+    ) {
+        StringBuilder jpql = getBuilder(id, title, level, algorithms);
+
+        TypedQuery<Problem> query = entityManager.createQuery(jpql.toString(), Problem.class);
+        if (id != null) query.setParameter("id", id);
+        if (title != null) query.setParameter("title", "%" + title + "%");
+        if (level != null) query.setParameter("level", level);
+        if (algorithms != null) query.setParameter("algorithms", "%" + algorithms + "%");
+        List<Problem> resultList = query.getResultList();
+
+        return resultList.stream().map(ResponseProblem::from).toList();
+    }
+
     @Transactional
     public ResponseProblem updateProblem(Long id, RequestUpdateProblem requestUpdateProblem) {
         Problem problem = problemRepository.findById(id)
@@ -39,4 +60,22 @@ public class ProblemService {
         return ResponseProblem.from(problem);
     }
 
+    private static StringBuilder getBuilder(Long id, String title, Integer level, String algorithms) {
+        StringBuilder jpql = new StringBuilder("select p from Problem p");
+        List<String> criteria = new ArrayList<>();
+
+        if (id != null) criteria.add(" p.id = :id");
+        if (title != null) criteria.add(" p.title like :title");
+        if (level != null) criteria.add(" p.level = :level");
+        if (algorithms != null) criteria.add(" p.algorithms like :algorithms");
+
+        if (!criteria.isEmpty()) jpql.append(" where ");
+
+        for (int i = 0; i < criteria.size(); i++) {
+            if (i > 0) jpql.append(" and ");
+            jpql.append(criteria.get(i));
+        }
+
+        return jpql;
+    }
 }

--- a/src/main/java/com/soundbar91/retrospect_project/controller/ProblemController.java
+++ b/src/main/java/com/soundbar91/retrospect_project/controller/ProblemController.java
@@ -8,6 +8,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequiredArgsConstructor
 public class ProblemController {
@@ -20,6 +22,17 @@ public class ProblemController {
     ) {
         ResponseProblem responseProblem = problemService.createProblem(requestCreateProblem);
         return ResponseEntity.ok(responseProblem);
+    }
+
+    @GetMapping("/problem")
+    public ResponseEntity<List<ResponseProblem>> findProblemByParams(
+            @RequestParam(value = "id", required = false) Long id,
+            @RequestParam(value = "title", required = false) String title,
+            @RequestParam(value = "level", required = false) Integer level,
+            @RequestParam(value = "algorithms", required = false) String algorithms
+    ) {
+        List<ResponseProblem> problemByParams = problemService.findProblemByParams(id, title, level, algorithms);
+        return ResponseEntity.ok(problemByParams);
     }
 
     @PutMapping("/problem/{id}")


### PR DESCRIPTION
수정해야할 사항
1. 현재는 JPQL로 구현이 되어있음. 후에 QueryDSL로 리펙토링 진행할 수 있으면 진행
2. 알고리즘 분류에 따른 검색 부분 수정이 필요함. 현재는 %~% 형식으로 찾는데, DB에 저장된 알고리즘 분류 순서와 찾고자 하는 알고리즘 분류 순서가 다른 경우 조회가 안 될것으로 예측이 됨. 